### PR TITLE
Removes confusing yarn output on `yarn install`

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "fix": "yarn run fix:prettier && yarn run fix:import-sort",
     "fix:import-sort": "import-sort --write 'src/**/*.js'",
     "fix:prettier": "prettier --write 'src/**/*.js'",
-    "prepublish": "yarn run --silent in-publish && yarn run actually-prepublish || echo",
+    "prepublish": "in-publish && yarn run actually-prepublish || echo",
     "actually-prepublish": "yarn build:clean && yarn run test && yarn run build",
     "test": "yarn run test:flow && yarn run test:jest && yarn run check",
     "test:flow": "flow check",


### PR DESCRIPTION
Running `yarn install` from current master produces this output:

```
$ yarn run --silent in-publish && yarn run actually-prepublish || echo
error Command failed with exit code 1.
```

According to `in-publish` docs (https://github.com/iarna/in-publish/blob/master/README.md) preferred way to use this util is to directly run `in-publish` (yarn/npm takes care about adding `node_modules/.bin/` to PATH for scripts in package.json)