### PR TITLE
Makes `cycle` properly work with infinite iterators

### DIFF
--- a/src/__tests__/itertools.test.js
+++ b/src/__tests__/itertools.test.js
@@ -74,6 +74,11 @@ describe('cycle', () => {
         expect(take(3, cycle(['x']))).toEqual(['x', 'x', 'x']);
         expect(take(5, cycle(['even', 'odd']))).toEqual(['even', 'odd', 'even', 'odd', 'even']);
     });
+
+    it('cycles with infinite iterable', () => {
+        // Function `cycle` should properly work with infinite iterators (`repeat('x')` in this case)
+        expect(take(3, cycle(repeat('x')))).toEqual(['x', 'x', 'x']);
+    });
 });
 
 describe('dropwhile', () => {

--- a/src/itertools.js
+++ b/src/itertools.js
@@ -64,9 +64,14 @@ export function compress<T>(data: Iterable<T>, selectors: Iterable<boolean>): Ar
  * copy.  Repeats indefinitely.
  */
 export function* cycle<T>(iterable: Iterable<T>): Iterable<T> {
-    let saved = [...iterable];
+    const saved = [];
+    for (const element of iterable) {
+        yield element;
+        saved.push(element);
+    }
+
     while (saved.length > 0) {
-        for (let element of saved) {
+        for (const element of saved) {
             yield element;
         }
     }


### PR DESCRIPTION
Currently function `cycle` tries to spread `iterable` to `saved`. This will cause `FATAL ERROR: CALL_AND_RETRY_LAST Allocation failed - JavaScript heap out of memory` for infinite `iterable`. Implementation in Python's itertools seems not to have this flaw: https://docs.python.org/3/library/itertools.html#itertools.cycle/

This PR changes implementation of `cycle` and adds unit test for it.
  