### PR TITLE
Enhanced TS types for groupyby

### DIFF
--- a/src/types/itertools.d.ts
+++ b/src/types/itertools.d.ts
@@ -5,7 +5,7 @@ export function count(start?: number, step?: number): Iterable<number>;
 export function compress<T>(data: Iterable<T>, selectors: Iterable<boolean>): T[];
 export function cycle<T>(iterable: Iterable<T>): Iterable<T>;
 export function dropwhile<T>(iterable: Iterable<T>, predicate: Predicate<T>): Iterable<T>;
-export function groupby<T>(iterable: Iterable<T>, keyFn?: (item: T) => Primitive): Iterable<[Primitive, Iterable<T>]>;
+export function groupby<T, U extends Primitive>(iterable: Iterable<T>, keyFn?: (item: T) => U): Iterable<[U, Iterable<T>]>;
 export function icompress<T>(data: Iterable<T>, selectors: Iterable<boolean>): Iterable<T>;
 export function ifilter<T>(iterable: Iterable<T>, predicate: Predicate<T>): Iterable<T>;
 export function imap<T, V>(iterable: Iterable<T>, mapper: (item: T) => V): Iterable<V>;


### PR DESCRIPTION
I made a small change to the `groupby` TypeScript type, as it used to return a `Primitive` type as the grouped value, instead of the actual Primitive "instance" type.
Note that there might be other places in the code that could benefit of that fix, I didn't went through all of the codebase but it might be a starting point!